### PR TITLE
Fix installation instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 ### Using Cask
 
-`brew cask install x-swiftformat`
+`brew install --cask x-swiftformat`
 
 ## Usage
 


### PR DESCRIPTION
`brew cask install x-swiftformat` is in `README.md`, but this doesn't work now because of update of Homebrew.

homebrew blog: [2.6.0 — Homebrew](https://brew.sh/2020/12/01/homebrew-2.6.0/)

> All brew cask commands have been deprecated in favour of brew commands (with --cask) when necessary

screenshot:
![Calling brew cask install is disabled](https://user-images.githubusercontent.com/8146876/103984681-ead4f280-51ca-11eb-806a-cd4a4dd64bc2.png)
