### PR TITLE
Fix open dialog to allow any file

### DIFF
--- a/x-swiftformat/X-SwiftFormat/Source/app/AppDelegate+Menu.swift
+++ b/x-swiftformat/X-SwiftFormat/Source/app/AppDelegate+Menu.swift
@@ -8,18 +8,11 @@ extension AppDelegate {
 			openPanel.showsHiddenFiles = true
 			openPanel.canChooseDirectories = false
 			openPanel.allowsMultipleSelection = false
-			openPanel.allowedFileTypes = [XSFDocType.swiftformat.rawValue]
+			openPanel.allowedFileTypes = nil
 
 			openPanel.beginSheetModal(for: window) { response in
-				if response.rawValue == 1 {
-					if let url = openPanel.urls.first {
-						if let docType = XSFDocType(rawValue: url.pathExtension.lowercased()) {
-							switch docType {
-							case .swiftformat:
-								XSFDocHandler.readSwiftFormatFile(with: url)
-							}
-						}
-					}
+				if response.rawValue == 1, let url = openPanel.url {
+					XSFDocHandler.readSwiftFormatFile(with: url)
 				}
 			}
 		}

--- a/x-swiftformat/X-SwiftFormat/Source/doc/XSFDoc.swift
+++ b/x-swiftformat/X-SwiftFormat/Source/doc/XSFDoc.swift
@@ -2,10 +2,6 @@ import Cocoa
 
 let kReadXSFFileNotification = NSNotification.Name(rawValue: "kReadXSFFileNotification")
 
-enum XSFDocType: String {
-	case swiftformat = "swift-format"
-}
-
 class XSFDoc: NSDocument {
 
 	override var windowNibName: String? {

--- a/x-swiftformat/X-SwiftFormat/Source/doc/XSFDocHandler.swift
+++ b/x-swiftformat/X-SwiftFormat/Source/doc/XSFDocHandler.swift
@@ -2,23 +2,6 @@ import Cocoa
 
 class XSFDocHandler: NSObject {
 
-	static func handle(filenames: [String]) {
-		for filename in filenames {
-			let components = filename.split(separator: "/")
-			if let last = components.last {
-				let split = last.split(separator: ".")
-				if split.count == 2 {
-					if let docType = XSFDocType(rawValue: String(split[1]).lowercased()) {
-						switch docType {
-						case .swiftformat:
-							readSwiftFormatFile(with: URL(fileURLWithPath: filename))
-						}
-					}
-				}
-			}
-		}
-	}
-
 	static func readSwiftFormatFile(with url: URL) {
 
 		if let data = try? Data(contentsOf: url), let json = data.json as? [String: Any] {


### PR DESCRIPTION
Since ec9c13d6 the file open dialog would only accept files with the `swift-format` suffix which is not what we want. This PR does the following:

* Removes the file type restriction
* Changes the file handling to try and load whatever file its given, if the JSON fails we simply don’t continue
* Removes duplicate file handling (confused me during debugging)

Tested locally with a build and works as expected.

Fixes #22 