### PR TITLE
Use 5.7 branch

### DIFF
--- a/x-swiftformat/X-SwiftFormat.xcodeproj/project.pbxproj
+++ b/x-swiftformat/X-SwiftFormat.xcodeproj/project.pbxproj
@@ -956,7 +956,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/apple/swift-format";
 			requirement = {
-				branch = release/5.6;
+				branch = release/5.7;
 				kind = branch;
 			};
 		};

--- a/x-swiftformat/X-SwiftFormat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/x-swiftformat/X-SwiftFormat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser.git",
       "state" : {
-        "revision" : "f3c9084a71ef4376f2fabbdf1d3d90a49f1fabdb",
-        "version" : "1.1.2"
+        "revision" : "9f39744e025c7d377987f30b03770805dcb0bcd1",
+        "version" : "1.1.4"
       }
     },
     {
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-format",
       "state" : {
-        "branch" : "release/5.6",
-        "revision" : "e6b8c60c7671066d229e30efa1e31acf57be412e"
+        "branch" : "release/5.7",
+        "revision" : "5f184220d032a019a63df457cdea4b9c8241e911"
       }
     },
     {
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-syntax",
       "state" : {
-        "revision" : "0b6c22b97f8e9320bca62e82cdbee601cf37ad3f",
-        "version" : "0.50600.1"
+        "revision" : "72d3da66b085c2299dd287c2be3b92b5ebd226de",
+        "version" : "0.50700.1"
       }
     },
     {
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-tools-support-core.git",
       "state" : {
-        "revision" : "b7667f3e266af621e5cc9c77e74cacd8e8c00cb4",
-        "version" : "0.2.5"
+        "revision" : "4f07be3dc201f6e2ee85b6942d0c220a16926811",
+        "version" : "0.2.7"
       }
     }
   ],


### PR DESCRIPTION
@ruiaureliano 
Hello, thank you for the helpful tool.
This time I'd like to update swift-format runtime up to Swift 5.7.

For now, I just bumped up the dependencies. I'm not sure what I should do for the next release.
Looks like `lib_InternalSwiftSyntaxParser.dylib` is not managed in this repo. does the release process bundle it into `.app` file?